### PR TITLE
Fix setup permision denied by removing unnecessary env variabe $PWD ,…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 run:
-	@/bin/sh $(PWD)/bin/run.sh
+	@/bin/bash bin/run.sh
 setup:
-	@/bin/sh $(PWD)/bin/setup.sh
+	@/bin/bash bin/setup.sh


### PR DESCRIPTION
Fix setup permision denied by removing unnecessary env variabe $PWD and using bash as default executor of bin files in Makefile
